### PR TITLE
to avoid 403 Forbidden

### DIFF
--- a/changelog.php
+++ b/changelog.php
@@ -52,8 +52,18 @@ require 'vendor/autoload.php';
 use DOMWrap\Document;
 
 $dom = new Document();
-$dom->html( file_get_contents( "https://buddypress.trac.wordpress.org/query?status=closed&milestone={$milestone}&group=component&max=99999&col=id&col=summary&order=priority" ) );
+$opts = array(
+  'http'=>array(
+    'user_agent' => 'My company name',
+    'method'=>"GET",
+    'header'=> implode("\r\n", array(
+      'Content-type: text/plain;'
+    ))
+  )
+);
 
+$context = stream_context_create($opts);
+$dom->html( file_get_contents( "https://buddypress.trac.wordpress.org/query?status=closed&milestone={$milestone}&group=component&max=99999&col=id&col=summary&order=priority",false, $context ) );
 $html .= '<h3 id="activity"><a href="#activity">Activity</a></h3>';
 
 foreach ( $dom->find( 'table.tickets tbody' ) as $i => $elem ) {


### PR DESCRIPTION
PHP Warning:  fopen(https://buddypress.trac.wordpress.org/query?status=closed&milestone=8.0.0&group=component&max=99999&col=id&col=summary&order=priority): failed to open stream: HTTP request failed! HTTP/1.1 403 Forbidden
 in bp-changelog\changelog.php on line 56